### PR TITLE
Update timeconst.pl

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -370,7 +370,7 @@ if ($hz eq '--can') {
 	}
 
 	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
+	if (!(@val)) {
 		@val = compute_values($hz);
 	}
 	output($hz, @val);


### PR DESCRIPTION
 timeconst.pl error fix
cause I had **Can't use 'defined(@array)'** when kernel was compiling